### PR TITLE
명령어 타임아웃 및 클릭 재시도 로직 개선

### DIFF
--- a/src/Config/AppSettings.cs
+++ b/src/Config/AppSettings.cs
@@ -7,6 +7,7 @@ namespace InvenAdClicker.Config
         public int RetryCount { get; set; } = 1;
         public int ClickDelayMilliseconds { get; set; } = 300;
         public int PageLoadTimeoutMilliseconds { get; set; } = 1000;
+        public int CommandTimeoutMilliSeconds { get; set; } = 10000;
         public bool DisableImages { get; set; } = true;
         public bool DisableCss { get; set; } = true;
         public bool DisableFonts { get; set; } = true;

--- a/src/Services/Selenium/SeleniumWebBrowser.cs
+++ b/src/Services/Selenium/SeleniumWebBrowser.cs
@@ -58,7 +58,10 @@ namespace InvenAdClicker.Services.Selenium
                 options.AddUserProfilePreference(
                     "profile.managed_default_content_settings.fonts", 2);
 
-            _driver = new ChromeDriver(service, options);
+            _driver = new ChromeDriver(
+                service,
+                options,
+                TimeSpan.FromMilliseconds(settings.CommandTimeoutMilliSeconds));
 
             encryption.LoadAndValidateCredentials(out var id, out var pw);
             _driver.Navigate().GoToUrl(_loginUrl);


### PR DESCRIPTION
`Commit Message by Copilot`

`AppSettings.cs`에 `CommandTimeoutMilliSeconds` 속성을 추가하여 명령어 타임아웃을 설정할 수 있게 하였습니다. `SeleniumAdClicker.cs`에서 클릭 시도 로직을 수정하여 실패 시 최대 재시도 횟수만큼 반복하고, 각 시도에서 경고 로그를 기록하며 브라우저 인스턴스를 새로 확보하도록 변경하였습니다. `SeleniumWebBrowser.cs`에서는 `ChromeDriver` 인스턴스를 생성할 때 `CommandTimeoutMilliSeconds` 설정을 적용하여 드라이버의 명령어 타임아웃을 조정하였습니다.