### PR TITLE
[codex] Harden pipeline and run logs

### DIFF
--- a/src/Program.cs
+++ b/src/Program.cs
@@ -89,9 +89,12 @@ namespace InvenAdClicker
                     };
                 }
 
-                await using var browser = await playwright.Chromium.LaunchAsync(launchOptions);
+                Task<IBrowser> LaunchBrowserAsync()
+                    => playwright.Chromium.LaunchAsync(launchOptions);
+
+                await using var browser = await LaunchBrowserAsync();
                 await LoginVerifier.VerifyPlaywrightAsync(browser, settings, logger, encryption, cts.Token);
-                await using var playwrightPool = new PlaywrightBrowserPool(browser, settings, logger, encryption);
+                await using var playwrightPool = new PlaywrightBrowserPool(browser, settings, logger, encryption, LaunchBrowserAsync);
                 await playwrightPool.InitializePoolAsync(cts.Token);
 
                 IAdCollector<IPage> adCollector = new PlaywrightAdCollector(settings, logger, progress);

--- a/src/Services/Pipeline/GenericPipelineRunner.cs
+++ b/src/Services/Pipeline/GenericPipelineRunner.cs
@@ -74,29 +74,17 @@ namespace InvenAdClicker.Services.Pipeline
 
             Task producerTask = ProduceUrlsAsync(urls, urlWriter, cancellationToken);
             Task[] clickers = StartClickers(clickerCount, clickReader, cancellationToken, idOffset: 0);
-            Task[] collectors = StartCollectors(collectorCount, urlReader, clickWriter, cancellationToken);
+            Task[] collectors = StartCollectors(
+                collectorCount,
+                urlReader,
+                clickWriter,
+                clickReader,
+                cancellationToken);
 
             try
             {
                 await producerTask;
                 await Task.WhenAll(collectors);
-                clickWriter.TryComplete();
-
-                // After collection completes, reuse the freed page permits to increase click throughput.
-                // This keeps total concurrency bounded by MaxDegreeOfParallelism while avoiding the long tail
-                // where a single clicker drains the remaining backlog.
-                if (clickerCount < mdp)
-                {
-                    var extraClickers = StartClickers(mdp - clickerCount, clickReader, cancellationToken, idOffset: clickerCount);
-                    if (extraClickers.Length > 0)
-                    {
-                        var merged = new Task[clickers.Length + extraClickers.Length];
-                        Array.Copy(clickers, 0, merged, 0, clickers.Length);
-                        Array.Copy(extraClickers, 0, merged, clickers.Length, extraClickers.Length);
-                        clickers = merged;
-                    }
-                }
-
                 await Task.WhenAll(clickers);
             }
             catch (OperationCanceledException)
@@ -142,8 +130,10 @@ namespace InvenAdClicker.Services.Pipeline
             int collectorCount,
             ChannelReader<string> urlReader,
             ChannelWriter<(string page, string link)> clickWriter,
+            ChannelReader<(string page, string link)> clickReader,
             CancellationToken cancellationToken)
         {
+            int remainingCollectors = collectorCount;
             var collectors = new Task[collectorCount];
             for (int i = 0; i < collectorCount; i++)
             {
@@ -157,6 +147,17 @@ namespace InvenAdClicker.Services.Pipeline
                         await foreach (var url in urlReader.ReadAllAsync(cancellationToken))
                         {
                             page = await CollectOneAsync(page, url, clickWriter, cancellationToken);
+                        }
+
+                        if (Interlocked.Decrement(ref remainingCollectors) == 0)
+                        {
+                            clickWriter.TryComplete();
+                        }
+
+                        _logger.Info($"[Collector:{workerId}] Switched to click queue");
+                        await foreach (var work in clickReader.ReadAllAsync(cancellationToken))
+                        {
+                            page = await ClickOneAsync(page, workerId, work.page, work.link, cancellationToken);
                         }
                     }
                     finally

--- a/src/Services/Pipeline/GenericPipelineRunner.cs
+++ b/src/Services/Pipeline/GenericPipelineRunner.cs
@@ -11,6 +11,7 @@ namespace InvenAdClicker.Services.Pipeline
 {
     public class GenericPipelineRunner<TPage> : IPipelineRunner where TPage : class
     {
+        private static readonly TimeSpan WorkerShutdownTimeout = TimeSpan.FromMilliseconds(500);
         private readonly AppSettings _settings;
         private readonly IAppLogger _logger;
         private readonly IBrowserPool<TPage> _browserPool;
@@ -83,20 +84,24 @@ namespace InvenAdClicker.Services.Pipeline
 
             try
             {
-                await producerTask;
-                await Task.WhenAll(collectors);
-                await Task.WhenAll(clickers);
+                await WaitForCompletionOrFirstFailureAsync(
+                    producerTask,
+                    cancellationToken,
+                    collectors,
+                    clickers);
             }
             catch (OperationCanceledException)
             {
                 urlWriter.TryComplete();
                 clickWriter.TryComplete();
+                await WaitForWorkersToStopAsync(WorkerShutdownTimeout, collectors, clickers);
                 throw;
             }
             catch (Exception ex)
             {
                 urlWriter.TryComplete(ex);
                 clickWriter.TryComplete(ex);
+                await WaitForWorkersToStopAsync(WorkerShutdownTimeout, collectors, clickers);
                 throw;
             }
             finally
@@ -106,6 +111,44 @@ namespace InvenAdClicker.Services.Pipeline
             }
 
             _logger.Info("파이프라인 실행이 완료되었습니다.");
+        }
+
+        private static async Task WaitForCompletionOrFirstFailureAsync(
+            Task producerTask,
+            CancellationToken cancellationToken,
+            params Task[][] taskGroups)
+        {
+            var activeTasks = new List<Task> { producerTask };
+            foreach (var taskGroup in taskGroups)
+            {
+                activeTasks.AddRange(taskGroup);
+            }
+
+            Task? cancellationTask = null;
+            if (cancellationToken.CanBeCanceled)
+            {
+                cancellationTask = Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+            }
+
+            while (activeTasks.Count > 0)
+            {
+                var waitTasks = new List<Task>(activeTasks.Count + (cancellationTask == null ? 0 : 1));
+                waitTasks.AddRange(activeTasks);
+                if (cancellationTask != null)
+                {
+                    waitTasks.Add(cancellationTask);
+                }
+
+                var completed = await Task.WhenAny(waitTasks);
+                activeTasks.Remove(completed);
+
+                if (completed == cancellationTask)
+                {
+                    await completed;
+                }
+
+                await completed;
+            }
         }
 
         private async Task ProduceUrlsAsync(string[] urls, ChannelWriter<string> writer, CancellationToken cancellationToken)
@@ -140,20 +183,34 @@ namespace InvenAdClicker.Services.Pipeline
                 int workerId = i;
                 collectors[i] = Task.Run(async () =>
                 {
-                    var page = await _browserPool.AcquireAsync(cancellationToken);
-                    _logger.Info($"[Collector:{workerId}] Started");
+                    TPage? page = null;
+                    bool collectorCompleted = false;
+
+                    void MarkCollectorCompleted()
+                    {
+                        if (collectorCompleted)
+                        {
+                            return;
+                        }
+
+                        collectorCompleted = true;
+                        if (Interlocked.Decrement(ref remainingCollectors) == 0)
+                        {
+                            clickWriter.TryComplete();
+                        }
+                    }
+
                     try
                     {
+                        page = await _browserPool.AcquireAsync(cancellationToken);
+                        _logger.Info($"[Collector:{workerId}] Started");
+
                         await foreach (var url in urlReader.ReadAllAsync(cancellationToken))
                         {
                             page = await CollectOneAsync(page, url, clickWriter, cancellationToken);
                         }
 
-                        if (Interlocked.Decrement(ref remainingCollectors) == 0)
-                        {
-                            clickWriter.TryComplete();
-                        }
-
+                        MarkCollectorCompleted();
                         _logger.Info($"[Collector:{workerId}] Switched to click queue");
                         await foreach (var work in clickReader.ReadAllAsync(cancellationToken))
                         {
@@ -162,12 +219,39 @@ namespace InvenAdClicker.Services.Pipeline
                     }
                     finally
                     {
-                        _browserPool.Release(page);
+                        MarkCollectorCompleted();
+                        if (page != null)
+                        {
+                            _browserPool.Release(page);
+                        }
                         _logger.Info($"[Collector:{workerId}] Ended");
                     }
                 }, cancellationToken);
             }
             return collectors;
+        }
+
+        private static async Task WaitForWorkersToStopAsync(TimeSpan timeout, params Task[][] taskGroups)
+        {
+            var tasks = new List<Task>();
+            foreach (var taskGroup in taskGroups)
+            {
+                tasks.AddRange(taskGroup);
+            }
+
+            var allTasks = Task.WhenAll(tasks);
+            try
+            {
+                var completed = await Task.WhenAny(allTasks, Task.Delay(timeout));
+                if (completed == allTasks)
+                {
+                    await allTasks;
+                }
+            }
+            catch
+            {
+                // Preserve the original exception from RunAsync while still giving workers a chance to exit.
+            }
         }
 
         private async Task<TPage> CollectOneAsync(

--- a/src/Services/Playwright/PlaywrightAdClicker.cs
+++ b/src/Services/Playwright/PlaywrightAdClicker.cs
@@ -55,6 +55,10 @@ namespace InvenAdClicker.Services.Playwright
                         $"goto={gotoMs}ms delay={delayMs}ms route={routeStats.FormatCompact()} total={swTotal.ElapsedMilliseconds}ms");
                     return page; // 성공
                 }
+                catch (OperationCanceledException)
+                {
+                    throw;
+                }
                 catch (Exception ex)
                 {
                     _logger.Warn($"Playwright 클릭 {i + 1}회차 실패('{link}'): {ex.Message}");

--- a/src/Services/Playwright/PlaywrightBrowserPool.cs
+++ b/src/Services/Playwright/PlaywrightBrowserPool.cs
@@ -16,14 +16,17 @@ namespace InvenAdClicker.Services.Playwright
         private readonly AppSettings _settings;
         private readonly IAppLogger _logger;
         private readonly Encryption _encryption;
-        private readonly IBrowser _browser;
+        private IBrowser _browser;
+        private readonly Func<Task<IBrowser>>? _browserFactory;
         private readonly ConcurrentBag<IPage> _pool;
         private readonly SemaphoreSlim _semaphore;
+        private readonly SemaphoreSlim _browserRestartLock = new(1, 1);
         private string? _storageStatePath;
 
-        public PlaywrightBrowserPool(IBrowser browser, AppSettings settings, IAppLogger logger, Encryption encryption)
+        public PlaywrightBrowserPool(IBrowser browser, AppSettings settings, IAppLogger logger, Encryption encryption, Func<Task<IBrowser>>? browserFactory = null)
         {
             _browser = browser;
+            _browserFactory = browserFactory;
             _settings = settings;
             _logger = logger;
             _encryption = encryption;
@@ -84,7 +87,23 @@ namespace InvenAdClicker.Services.Playwright
                 JavaScriptEnabled = _settings.Debug.Enabled ? _settings.Debug.JavaScriptEnabled : true,
                 StorageStatePath = _storageStatePath // Inject authenticated session
             };
-            var context = await _browser.NewContextAsync(contextOptions);
+
+            var browser = await GetConnectedBrowserAsync(cancellationToken);
+            try
+            {
+                return await CreatePageAsync(browser, contextOptions);
+            }
+            catch (Exception ex) when (IsBrowserTargetClosed(ex) && _browserFactory != null)
+            {
+                _logger.Warn($"Playwright 브라우저 연결이 종료되어 재시작합니다: {ex.Message}");
+                await RestartBrowserAsync(browser, cancellationToken);
+                return await CreatePageAsync(_browser, contextOptions);
+            }
+        }
+
+        private async Task<IPage> CreatePageAsync(IBrowser browser, BrowserNewContextOptions contextOptions)
+        {
+            var context = await browser.NewContextAsync(contextOptions);
             var page = await context.NewPageAsync();
 
             // Setup Network Routes (Blockers)
@@ -171,6 +190,73 @@ namespace InvenAdClicker.Services.Playwright
             return page;
         }
 
+        private async Task<IBrowser> GetConnectedBrowserAsync(CancellationToken cancellationToken)
+        {
+            var browser = _browser;
+            if (browser.IsConnected || _browserFactory == null)
+            {
+                return browser;
+            }
+
+            _logger.Warn("Playwright 브라우저 연결이 끊겨 재시작합니다.");
+            await RestartBrowserAsync(browser, cancellationToken);
+            return _browser;
+        }
+
+        private async Task RestartBrowserAsync(IBrowser failedBrowser, CancellationToken cancellationToken)
+        {
+            if (_browserFactory == null)
+            {
+                return;
+            }
+
+            await _browserRestartLock.WaitAsync(cancellationToken);
+            try
+            {
+                if (!ReferenceEquals(_browser, failedBrowser) && _browser.IsConnected)
+                {
+                    return;
+                }
+
+                await ClosePooledPagesAsync();
+
+                try
+                {
+                    if (failedBrowser.IsConnected)
+                    {
+                        await failedBrowser.CloseAsync();
+                    }
+                }
+                catch
+                {
+                    // The browser may already be gone; restart is still the recovery path.
+                }
+
+                _browser = await _browserFactory();
+                _logger.Info("Playwright 브라우저 재시작 완료");
+            }
+            finally
+            {
+                _browserRestartLock.Release();
+            }
+        }
+
+        private async Task ClosePooledPagesAsync()
+        {
+            while (_pool.TryTake(out var page))
+            {
+                try { await page.Context.CloseAsync(); }
+                catch { /* 무시 */ }
+            }
+        }
+
+        private static bool IsBrowserTargetClosed(Exception ex)
+        {
+            return ex.GetType().FullName == "Microsoft.Playwright.TargetClosedException"
+                || (ex is PlaywrightException
+                    && ex.Message.Contains("Target page, context or browser has been closed", StringComparison.OrdinalIgnoreCase));
+        }
+
         [System.Runtime.Versioning.SupportedOSPlatform("windows")]
         private async Task CreateAndPoolPageAsync(CancellationToken cancellationToken)
         {
@@ -209,7 +295,7 @@ namespace InvenAdClicker.Services.Playwright
 
         public void Release(IPage page)
         {
-            if (page != null && !page.IsClosed)
+            if (IsPageReusable(page))
             {
                 _pool.Add(page);
                 _semaphore.Release();
@@ -218,6 +304,24 @@ namespace InvenAdClicker.Services.Playwright
             {
                 _logger.Warn("null 또는 종료된 페이지를 반환했습니다. 새로 생성합니다.");
                 _semaphore.Release(); // Just release the slot, don't auto-recreate here (Runner will handle)
+            }
+        }
+
+        private static bool IsPageReusable(IPage? page)
+        {
+            if (page == null || page.IsClosed)
+            {
+                return false;
+            }
+
+            try
+            {
+                var browser = page.Context?.Browser;
+                return browser?.IsConnected == true;
+            }
+            catch
+            {
+                return false;
             }
         }
 
@@ -280,13 +384,19 @@ namespace InvenAdClicker.Services.Playwright
 
         public async ValueTask DisposeAsync()
         {
-            while (_pool.TryTake(out var page))
-            {
-                try { await page.Context.CloseAsync(); }
-                catch { /* 무시 */ }
-            }
+            await ClosePooledPagesAsync();
 
-            await _browser.CloseAsync();
+            try
+            {
+                if (_browser.IsConnected)
+                {
+                    await _browser.CloseAsync();
+                }
+            }
+            catch
+            {
+                // Disconnected browsers are already gone; disposal should stay best-effort.
+            }
             
             // Clean up temp file
             if (!string.IsNullOrEmpty(_storageStatePath) && File.Exists(_storageStatePath))

--- a/src/Services/Playwright/PlaywrightBrowserPool.cs
+++ b/src/Services/Playwright/PlaywrightBrowserPool.cs
@@ -303,7 +303,25 @@ namespace InvenAdClicker.Services.Playwright
             else
             {
                 _logger.Warn("null 또는 종료된 페이지를 반환했습니다. 새로 생성합니다.");
+                ClosePageContextBestEffort(page);
                 _semaphore.Release(); // Just release the slot, don't auto-recreate here (Runner will handle)
+            }
+        }
+
+        private static void ClosePageContextBestEffort(IPage? page)
+        {
+            if (page == null)
+            {
+                return;
+            }
+
+            try
+            {
+                page.Context.CloseAsync().GetAwaiter().GetResult();
+            }
+            catch
+            {
+                // The page/context/browser may already be closed.
             }
         }
 

--- a/src/Utils/RollingFileLoggerProvider.cs
+++ b/src/Utils/RollingFileLoggerProvider.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.Logging;
 using System;
+using System.Diagnostics;
 using System.IO;
 using System.Text;
 using System.Threading;
@@ -17,6 +18,14 @@ namespace InvenAdClicker.Utils
             _logger = new RollingFileLogger();
         }
 
+        public RollingFileLoggerProvider(
+            int capacity,
+            Func<string, string, Encoding, CancellationToken, Task>? fileAppender = null,
+            TimeSpan? disposeTimeout = null)
+        {
+            _logger = new RollingFileLogger(capacity, fileAppender, disposeTimeout);
+        }
+
         public ILogger CreateLogger(string categoryName) => _logger;
 
         public void Dispose()
@@ -29,6 +38,10 @@ namespace InvenAdClicker.Utils
             private readonly Channel<LogEntry> _logChannel;
             private readonly Task _writeTask;
             private readonly CancellationTokenSource _cts;
+            private readonly string _runLogPath;
+            private readonly string _fatalRunLogPath;
+            private readonly Func<string, string, Encoding, CancellationToken, Task> _fileAppender;
+            private readonly TimeSpan _disposeTimeout;
             private static readonly UTF8Encoding Utf8NoBom = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
 
             private struct LogEntry
@@ -40,29 +53,47 @@ namespace InvenAdClicker.Utils
                 public Exception? Exception;
             }
 
-            public RollingFileLogger()
+            public RollingFileLogger(
+                int capacity = 10000,
+                Func<string, string, Encoding, CancellationToken, Task>? fileAppender = null,
+                TimeSpan? disposeTimeout = null)
             {
-                // Bounded Channel to apply backpressure if disk I/O is too slow
-                _logChannel = Channel.CreateBounded<LogEntry>(new BoundedChannelOptions(10000)
+                // Keep logging bounded and non-blocking if disk I/O falls behind.
+                _logChannel = Channel.CreateBounded<LogEntry>(new BoundedChannelOptions(Math.Max(1, capacity))
                 {
                     SingleReader = true,
                     SingleWriter = false,
-                    FullMode = BoundedChannelFullMode.DropOldest // Prevent memory bloat
+                    FullMode = BoundedChannelFullMode.DropOldest
                 });
                 _cts = new CancellationTokenSource();
+                var processStartedAt = Process.GetCurrentProcess().StartTime;
+                _runLogPath = GetRunPath(processStartedAt);
+                _fatalRunLogPath = GetFatalRunPath(processStartedAt);
+                _fileAppender = fileAppender ?? File.AppendAllTextAsync;
+                _disposeTimeout = disposeTimeout ?? TimeSpan.FromSeconds(1);
                 _writeTask = Task.Run(ProcessLogQueue);
             }
 
             public void Dispose()
             {
                 _logChannel.Writer.TryComplete();
-                _cts.Cancel();
+                var completed = false;
                 try
                 {
-                    _writeTask.Wait(1000); // Wait for remaining logs to flush
+                    completed = _writeTask.Wait(_disposeTimeout);
                 }
                 catch { }
-                _cts.Dispose();
+
+                if (!completed)
+                {
+                    try { _cts.Cancel(); } catch { }
+                    try { completed = _writeTask.Wait(TimeSpan.FromMilliseconds(100)); } catch { }
+                }
+
+                if (completed)
+                {
+                    _cts.Dispose();
+                }
             }
 
             public IDisposable? BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
@@ -91,7 +122,7 @@ namespace InvenAdClicker.Utils
             {
                 try
                 {
-                    while (await _logChannel.Reader.WaitToReadAsync(_cts.Token))
+                    while (await _logChannel.Reader.WaitToReadAsync())
                     {
                         while (_logChannel.Reader.TryRead(out var entry))
                         {
@@ -133,8 +164,7 @@ namespace InvenAdClicker.Utils
                 // File I/O is now async and lock-free (single consumer)
                 try
                 {
-                    var dailyPath = GetDailyPath(entry.Timestamp);
-                    EnsureDirectory(dailyPath);
+                    EnsureDirectory(_runLogPath);
                     
                     var sb = new StringBuilder();
                     sb.AppendLine(line);
@@ -143,13 +173,12 @@ namespace InvenAdClicker.Utils
                         sb.AppendLine(entry.Exception.ToString());
                     }
 
-                    await File.AppendAllTextAsync(dailyPath, sb.ToString(), Utf8NoBom, _cts.Token);
+                    await _fileAppender(_runLogPath, sb.ToString(), Utf8NoBom, _cts.Token);
 
                     if (entry.Level == LogLevel.Critical)
                     {
-                        var fatalPath = GetFatalPath(entry.Timestamp);
-                        EnsureDirectory(fatalPath);
-                        await File.AppendAllTextAsync(fatalPath, sb.ToString(), Utf8NoBom, _cts.Token);
+                        EnsureDirectory(_fatalRunLogPath);
+                        await _fileAppender(_fatalRunLogPath, sb.ToString(), Utf8NoBom, _cts.Token);
                     }
                 }
                 catch
@@ -163,17 +192,17 @@ namespace InvenAdClicker.Utils
                 return $"[{entry.Timestamp:yyyy-MM-dd HH:mm:ss,fff}][{MapLevel(entry.Level)}] {entry.Message}";
             }
 
-            private static string GetDailyPath(DateTime now)
+            private static string GetRunPath(DateTime processStartedAt)
             {
-                var dir = Path.Combine("logs", now.ToString("yyyy"), now.ToString("MM"));
-                var file = now.ToString("yyyy-MM-dd") + ".log";
+                var dir = Path.Combine("logs", processStartedAt.ToString("yyyy"), processStartedAt.ToString("MM"));
+                var file = processStartedAt.ToString("yyyy-MM-dd_HH-mm-ss-fff") + ".log";
                 return Path.Combine(dir, file);
             }
 
-            private static string GetFatalPath(DateTime now)
+            private static string GetFatalRunPath(DateTime processStartedAt)
             {
-                var dir = Path.Combine("logs", "fatal", now.ToString("yyyy"), now.ToString("MM"));
-                var file = now.ToString("yyyy-MM-dd") + ".log";
+                var dir = Path.Combine("logs", "fatal", processStartedAt.ToString("yyyy"), processStartedAt.ToString("MM"));
+                var file = processStartedAt.ToString("yyyy-MM-dd_HH-mm-ss-fff") + ".log";
                 return Path.Combine(dir, file);
             }
 

--- a/tests/InvenAdClicker.Tests/InvenAdClicker.Tests.csproj
+++ b/tests/InvenAdClicker.Tests/InvenAdClicker.Tests.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="NUnit" Version="4.2.2" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.4.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\InvenAdClicker.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/InvenAdClicker.Tests/Services/Pipeline/GenericPipelineRunnerTests.cs
+++ b/tests/InvenAdClicker.Tests/Services/Pipeline/GenericPipelineRunnerTests.cs
@@ -1,0 +1,171 @@
+using InvenAdClicker.Models;
+using InvenAdClicker.Services.Interfaces;
+using InvenAdClicker.Services.Pipeline;
+using InvenAdClicker.Utils;
+using NUnit.Framework;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace InvenAdClicker.Tests.Services.Pipeline
+{
+    [TestFixture]
+    public class GenericPipelineRunnerTests
+    {
+        [Test]
+        public async Task IdleCollectorSwitchesToClickingBeforeAllCollectorsFinish()
+        {
+            string slowUrl = $"slow-{Guid.NewGuid():N}";
+            string burstUrl = $"burst-{Guid.NewGuid():N}";
+            var progress = ProgressTracker.Instance;
+            progress.Initialize(new[] { slowUrl, burstUrl });
+
+            var slowCollectionRelease = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var clickRelease = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var secondClickerObserved = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var startedClickerIds = new ConcurrentDictionary<int, byte>();
+
+            var settings = new AppSettings
+            {
+                MaxDegreeOfParallelism = 4
+            };
+
+            var runner = new GenericPipelineRunner<string>(
+                settings,
+                new TestLogger(),
+                new TestBrowserPool(),
+                progress,
+                new DelegateCollector(async (_, url, cancellationToken) =>
+                {
+                    if (url == slowUrl)
+                    {
+                        await slowCollectionRelease.Task.WaitAsync(cancellationToken);
+                        return new List<string>();
+                    }
+
+                    return new List<string> { "link-1", "link-2", "link-3" };
+                }),
+                new DelegateClicker(async (page, _, clickerId, cancellationToken) =>
+                {
+                    startedClickerIds.TryAdd(clickerId, 0);
+                    if (startedClickerIds.Count >= 2)
+                    {
+                        secondClickerObserved.TrySetResult();
+                    }
+
+                    await clickRelease.Task.WaitAsync(cancellationToken);
+                    return page;
+                }));
+
+            var runTask = runner.RunAsync(new[] { slowUrl, burstUrl }, CancellationToken.None);
+
+            try
+            {
+                bool switchedEarly = await WaitForAsync(secondClickerObserved.Task, TimeSpan.FromSeconds(1));
+                Assert.That(switchedEarly, Is.True,
+                    "남는 수집 워커는 모든 수집 종료를 기다리지 않고 클릭 작업으로 전환되어야 합니다.");
+            }
+            finally
+            {
+                slowCollectionRelease.TrySetResult();
+                clickRelease.TrySetResult();
+                await runTask;
+            }
+        }
+
+        private static async Task<bool> WaitForAsync(Task task, TimeSpan timeout)
+        {
+            Task completed = await Task.WhenAny(task, Task.Delay(timeout));
+            return completed == task;
+        }
+
+        private sealed class DelegateCollector : IAdCollector<string>
+        {
+            private readonly Func<string, string, CancellationToken, Task<List<string>>> _collectAsync;
+
+            public DelegateCollector(Func<string, string, CancellationToken, Task<List<string>>> collectAsync)
+            {
+                _collectAsync = collectAsync;
+            }
+
+            public Task<List<string>> CollectLinksAsync(string page, string url, CancellationToken cancellationToken)
+            {
+                return _collectAsync(page, url, cancellationToken);
+            }
+        }
+
+        private sealed class DelegateClicker : IAdClicker<string>
+        {
+            private readonly Func<string, string, int, CancellationToken, Task<string>> _clickAsync;
+
+            public DelegateClicker(Func<string, string, int, CancellationToken, Task<string>> clickAsync)
+            {
+                _clickAsync = clickAsync;
+            }
+
+            public Task<string> ClickAdAsync(string page, string link, int clickerId, CancellationToken cancellationToken)
+            {
+                return _clickAsync(page, link, clickerId, cancellationToken);
+            }
+        }
+
+        private sealed class TestBrowserPool : IBrowserPool<string>
+        {
+            private int _nextPageId;
+
+            public Task InitializePoolAsync(CancellationToken cancellationToken = default)
+            {
+                return Task.CompletedTask;
+            }
+
+            public Task<string> AcquireAsync(CancellationToken cancellationToken = default)
+            {
+                string page = $"page-{Interlocked.Increment(ref _nextPageId)}";
+                return Task.FromResult(page);
+            }
+
+            public void Release(string browser)
+            {
+            }
+
+            public Task<string> RenewAsync(string oldBrowser, CancellationToken cancellationToken = default)
+            {
+                return AcquireAsync(cancellationToken);
+            }
+
+            public ValueTask DisposeAsync()
+            {
+                return ValueTask.CompletedTask;
+            }
+
+            public void Dispose()
+            {
+            }
+        }
+
+        private sealed class TestLogger : IAppLogger
+        {
+            public void Debug(string msg)
+            {
+            }
+
+            public void Error(string msg, Exception? ex = null)
+            {
+            }
+
+            public void Fatal(string msg, Exception? ex = null)
+            {
+            }
+
+            public void Info(string msg)
+            {
+            }
+
+            public void Warn(string msg)
+            {
+            }
+        }
+    }
+}

--- a/tests/InvenAdClicker.Tests/Services/Pipeline/GenericPipelineRunnerTests.cs
+++ b/tests/InvenAdClicker.Tests/Services/Pipeline/GenericPipelineRunnerTests.cs
@@ -75,6 +75,137 @@ namespace InvenAdClicker.Tests.Services.Pipeline
             }
         }
 
+        [Test]
+        public async Task CollectorFaultBeforeClickQueueSwitchDoesNotLeaveOtherCollectorsWaitingForever()
+        {
+            string faultUrl = $"fault-{Guid.NewGuid():N}";
+            string normalUrl = $"normal-{Guid.NewGuid():N}";
+            var progress = ProgressTracker.Instance;
+            progress.Initialize(new[] { faultUrl, normalUrl });
+
+            using var cts = new CancellationTokenSource();
+            var settings = new AppSettings
+            {
+                MaxDegreeOfParallelism = 3
+            };
+
+            var runner = new GenericPipelineRunner<string>(
+                settings,
+                new TestLogger(),
+                new RenewFailingBrowserPool(),
+                progress,
+                new DelegateCollector((_, url, _) =>
+                {
+                    if (url == faultUrl)
+                    {
+                        throw new InvalidOperationException("collection failed");
+                    }
+
+                    return Task.FromResult(new List<string>());
+                }),
+                new DelegateClicker((page, _, _, _) => Task.FromResult(page)));
+
+            var runTask = runner.RunAsync(new[] { faultUrl, normalUrl }, cts.Token);
+
+            try
+            {
+                Task completed = await Task.WhenAny(runTask, Task.Delay(TimeSpan.FromSeconds(1)));
+                Assert.That(completed, Is.SameAs(runTask),
+                    "Collector fault must complete the click queue so peer collectors do not wait forever.");
+                Assert.ThrowsAsync<InvalidOperationException>(async () => await runTask);
+            }
+            finally
+            {
+                cts.Cancel();
+                try { await runTask; } catch { }
+            }
+        }
+
+        [Test]
+        public async Task WorkerFaultDoesNotWaitForeverForNonCooperativePeer()
+        {
+            string clickUrl = $"click-{Guid.NewGuid():N}";
+            string faultUrl = $"fault-{Guid.NewGuid():N}";
+            var progress = ProgressTracker.Instance;
+            progress.Initialize(new[] { clickUrl, faultUrl });
+
+            var clickStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var releaseClicker = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var settings = new AppSettings
+            {
+                MaxDegreeOfParallelism = 3
+            };
+
+            var runner = new GenericPipelineRunner<string>(
+                settings,
+                new TestLogger(),
+                new RenewFailingBrowserPool(),
+                progress,
+                new DelegateCollector(async (_, url, cancellationToken) =>
+                {
+                    if (url == faultUrl)
+                    {
+                        await clickStarted.Task.WaitAsync(cancellationToken);
+                        throw new InvalidOperationException("collection failed");
+                    }
+
+                    return new List<string> { "link-1" };
+                }),
+                new DelegateClicker(async (page, _, _, _) =>
+                {
+                    clickStarted.TrySetResult();
+                    await releaseClicker.Task;
+                    return page;
+                }));
+
+            var runTask = runner.RunAsync(new[] { clickUrl, faultUrl }, CancellationToken.None);
+
+            try
+            {
+                Task completed = await Task.WhenAny(runTask, Task.Delay(TimeSpan.FromSeconds(2)));
+                Assert.That(completed, Is.SameAs(runTask),
+                    "A worker fault must not wait forever for a peer stuck in in-flight browser work.");
+                Assert.ThrowsAsync<InvalidOperationException>(async () => await runTask);
+            }
+            finally
+            {
+                releaseClicker.TrySetResult();
+                try { await runTask; } catch { }
+            }
+        }
+
+        [Test]
+        public async Task CancelableTokenDoesNotPreventSuccessfulPipelineCompletion()
+        {
+            string normalUrl = $"normal-{Guid.NewGuid():N}";
+            var progress = ProgressTracker.Instance;
+            progress.Initialize(new[] { normalUrl });
+
+            using var cts = new CancellationTokenSource();
+            var runner = new GenericPipelineRunner<string>(
+                new AppSettings { MaxDegreeOfParallelism = 2 },
+                new TestLogger(),
+                new TestBrowserPool(),
+                progress,
+                new DelegateCollector((_, _, _) => Task.FromResult(new List<string>())),
+                new DelegateClicker((page, _, _, _) => Task.FromResult(page)));
+
+            var runTask = runner.RunAsync(new[] { normalUrl }, cts.Token);
+
+            try
+            {
+                Task completed = await Task.WhenAny(runTask, Task.Delay(TimeSpan.FromSeconds(1)));
+                Assert.That(completed, Is.SameAs(runTask),
+                    "A cancelable token must not keep a successful pipeline waiting forever.");
+                await runTask;
+            }
+            finally
+            {
+                cts.Cancel();
+                try { await runTask; } catch { }
+            }
+        }
+
         private static async Task<bool> WaitForAsync(Task task, TimeSpan timeout)
         {
             Task completed = await Task.WhenAny(task, Task.Delay(timeout));
@@ -133,6 +264,40 @@ namespace InvenAdClicker.Tests.Services.Pipeline
             public Task<string> RenewAsync(string oldBrowser, CancellationToken cancellationToken = default)
             {
                 return AcquireAsync(cancellationToken);
+            }
+
+            public ValueTask DisposeAsync()
+            {
+                return ValueTask.CompletedTask;
+            }
+
+            public void Dispose()
+            {
+            }
+        }
+
+        private sealed class RenewFailingBrowserPool : IBrowserPool<string>
+        {
+            private int _nextPageId;
+
+            public Task InitializePoolAsync(CancellationToken cancellationToken = default)
+            {
+                return Task.CompletedTask;
+            }
+
+            public Task<string> AcquireAsync(CancellationToken cancellationToken = default)
+            {
+                string page = $"page-{Interlocked.Increment(ref _nextPageId)}";
+                return Task.FromResult(page);
+            }
+
+            public void Release(string browser)
+            {
+            }
+
+            public Task<string> RenewAsync(string oldBrowser, CancellationToken cancellationToken = default)
+            {
+                throw new InvalidOperationException("renew failed");
             }
 
             public ValueTask DisposeAsync()

--- a/tests/InvenAdClicker.Tests/Services/Playwright/PlaywrightAdClickerTests.cs
+++ b/tests/InvenAdClicker.Tests/Services/Playwright/PlaywrightAdClickerTests.cs
@@ -1,0 +1,75 @@
+using InvenAdClicker.Models;
+using InvenAdClicker.Services.Interfaces;
+using InvenAdClicker.Services.Playwright;
+using InvenAdClicker.Utils;
+using Microsoft.Playwright;
+using Moq;
+using NUnit.Framework;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace InvenAdClicker.Tests.Services.Playwright
+{
+    [TestFixture]
+    public class PlaywrightAdClickerTests
+    {
+        [Test]
+        public void ClickAdAsync_PropagatesCancellationWithoutRenewingPage()
+        {
+            var page = new Mock<IPage>(MockBehavior.Strict);
+            page.Setup(item => item.GotoAsync(
+                    "https://example.test/ad",
+                    It.IsAny<PageGotoOptions>()))
+                .ReturnsAsync((IResponse?)null);
+
+            var browserPool = new Mock<IBrowserPool<IPage>>(MockBehavior.Strict);
+            browserPool.Setup(item => item.RenewAsync(page.Object, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(page.Object);
+
+            var clicker = new PlaywrightAdClicker(
+                new AppSettings
+                {
+                    MaxClickAttempts = 2,
+                    ClickDelayMilliseconds = 1000,
+                    PageLoadTimeoutMilliseconds = 1000
+                },
+                new TestLogger(),
+                browserPool.Object);
+
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+
+            Assert.ThrowsAsync(
+                Is.InstanceOf<OperationCanceledException>(),
+                () => clicker.ClickAdAsync(page.Object, "https://example.test/ad", clickerId: 0, cts.Token));
+
+            browserPool.Verify(
+                item => item.RenewAsync(It.IsAny<IPage>(), It.IsAny<CancellationToken>()),
+                Times.Never);
+        }
+
+        private sealed class TestLogger : IAppLogger
+        {
+            public void Debug(string msg)
+            {
+            }
+
+            public void Error(string msg, Exception? ex = null)
+            {
+            }
+
+            public void Fatal(string msg, Exception? ex = null)
+            {
+            }
+
+            public void Info(string msg)
+            {
+            }
+
+            public void Warn(string msg)
+            {
+            }
+        }
+    }
+}

--- a/tests/InvenAdClicker.Tests/Services/Playwright/PlaywrightBrowserPoolTests.cs
+++ b/tests/InvenAdClicker.Tests/Services/Playwright/PlaywrightBrowserPoolTests.cs
@@ -1,0 +1,178 @@
+using InvenAdClicker.Models;
+using InvenAdClicker.Services.Playwright;
+using InvenAdClicker.Utils;
+using Microsoft.Playwright;
+using Moq;
+using NUnit.Framework;
+using System;
+using System.Threading.Tasks;
+
+namespace InvenAdClicker.Tests.Services.Playwright
+{
+    [TestFixture]
+    public class PlaywrightBrowserPoolTests
+    {
+        [Test]
+        public async Task RenewAsync_RelaunchesBrowserWhenCurrentBrowserIsDisconnected()
+        {
+            var disconnected = CreateBrowser(connected: false);
+            var replacement = CreateBrowser(connected: true);
+            int launches = 0;
+
+            var pool = new PlaywrightBrowserPool(
+                disconnected.Browser.Object,
+                new AppSettings { MaxDegreeOfParallelism = 1 },
+                new TestLogger(),
+                new Encryption(),
+                () =>
+                {
+                    launches++;
+                    return Task.FromResult(replacement.Browser.Object);
+                });
+
+            var oldPage = CreatePage().Page.Object;
+
+            var renewedPage = await pool.RenewAsync(oldPage);
+
+            Assert.That(renewedPage, Is.SameAs(replacement.Page.Object));
+            Assert.That(launches, Is.EqualTo(1));
+            disconnected.Browser.Verify(
+                browser => browser.NewContextAsync(It.IsAny<BrowserNewContextOptions>()),
+                Times.Never);
+            replacement.Browser.Verify(
+                browser => browser.NewContextAsync(It.IsAny<BrowserNewContextOptions>()),
+                Times.Once);
+        }
+
+        [Test]
+        public async Task Release_DoesNotReturnPagesFromDisconnectedBrowserToPool()
+        {
+            bool originalConnected = true;
+            var original = CreateBrowser(() => originalConnected);
+            var replacement = CreateBrowser(connected: true);
+
+            var pool = new PlaywrightBrowserPool(
+                original.Browser.Object,
+                new AppSettings { MaxDegreeOfParallelism = 1 },
+                new TestLogger(),
+                new Encryption(),
+                () => Task.FromResult(replacement.Browser.Object));
+
+            var stalePage = await pool.AcquireAsync();
+            originalConnected = false;
+
+            pool.Release(stalePage);
+            var acquiredAfterDisconnect = await pool.AcquireAsync();
+
+            Assert.That(acquiredAfterDisconnect, Is.SameAs(replacement.Page.Object));
+            Assert.That(acquiredAfterDisconnect, Is.Not.SameAs(stalePage));
+        }
+
+        [Test]
+        public async Task DisposeAsync_DoesNotCloseDisconnectedBrowser()
+        {
+            var disconnected = CreateBrowser(connected: false);
+            var pool = new PlaywrightBrowserPool(
+                disconnected.Browser.Object,
+                new AppSettings { MaxDegreeOfParallelism = 1 },
+                new TestLogger(),
+                new Encryption());
+
+            await pool.DisposeAsync();
+
+            disconnected.Browser.Verify(
+                browser => browser.CloseAsync(It.IsAny<BrowserCloseOptions>()),
+                Times.Never);
+        }
+
+        private static BrowserFixture CreateBrowser(bool connected)
+        {
+            return CreateBrowser(() => connected);
+        }
+
+        private static BrowserFixture CreateBrowser(Func<bool> isConnected)
+        {
+            var page = CreatePage();
+            var browser = new Mock<IBrowser>(MockBehavior.Strict);
+            browser.SetupGet(item => item.IsConnected).Returns(isConnected);
+            browser.Setup(item => item.NewContextAsync(It.IsAny<BrowserNewContextOptions>()))
+                .ReturnsAsync(page.Context.Object);
+            browser.Setup(item => item.CloseAsync(It.IsAny<BrowserCloseOptions>()))
+                .Returns(Task.CompletedTask);
+            page.Context.SetupGet(item => item.Browser).Returns(browser.Object);
+
+            return new BrowserFixture(browser, page.Context, page.Page);
+        }
+
+        private static PageFixture CreatePage()
+        {
+            var context = new Mock<IBrowserContext>(MockBehavior.Strict);
+            var page = new Mock<IPage>(MockBehavior.Strict);
+
+            page.SetupGet(item => item.Context).Returns(context.Object);
+            page.SetupGet(item => item.IsClosed).Returns(false);
+            page.Setup(item => item.RouteAsync(
+                    "**/*",
+                    It.IsAny<Func<IRoute, Task>>(),
+                    It.IsAny<PageRouteOptions>()))
+                .Returns(Task.CompletedTask);
+            page.Setup(item => item.AddInitScriptAsync(It.IsAny<string>(), It.IsAny<string>()))
+                .Returns(Task.CompletedTask);
+
+            context.Setup(item => item.NewPageAsync()).ReturnsAsync(page.Object);
+            context.Setup(item => item.CloseAsync(It.IsAny<BrowserContextCloseOptions>()))
+                .Returns(Task.CompletedTask);
+
+            return new PageFixture(context, page);
+        }
+
+        private sealed class BrowserFixture
+        {
+            public BrowserFixture(Mock<IBrowser> browser, Mock<IBrowserContext> context, Mock<IPage> page)
+            {
+                Browser = browser;
+                Context = context;
+                Page = page;
+            }
+
+            public Mock<IBrowser> Browser { get; }
+            public Mock<IBrowserContext> Context { get; }
+            public Mock<IPage> Page { get; }
+        }
+
+        private sealed class PageFixture
+        {
+            public PageFixture(Mock<IBrowserContext> context, Mock<IPage> page)
+            {
+                Context = context;
+                Page = page;
+            }
+
+            public Mock<IBrowserContext> Context { get; }
+            public Mock<IPage> Page { get; }
+        }
+
+        private sealed class TestLogger : IAppLogger
+        {
+            public void Debug(string msg)
+            {
+            }
+
+            public void Error(string msg, Exception? ex = null)
+            {
+            }
+
+            public void Fatal(string msg, Exception? ex = null)
+            {
+            }
+
+            public void Info(string msg)
+            {
+            }
+
+            public void Warn(string msg)
+            {
+            }
+        }
+    }
+}

--- a/tests/InvenAdClicker.Tests/Services/Playwright/PlaywrightBrowserPoolTests.cs
+++ b/tests/InvenAdClicker.Tests/Services/Playwright/PlaywrightBrowserPoolTests.cs
@@ -69,6 +69,27 @@ namespace InvenAdClicker.Tests.Services.Playwright
         }
 
         [Test]
+        public async Task Release_ClosesContextForUnusablePage()
+        {
+            var browser = CreateBrowser(connected: true);
+            browser.Page.SetupGet(item => item.IsClosed).Returns(true);
+
+            var pool = new PlaywrightBrowserPool(
+                browser.Browser.Object,
+                new AppSettings { MaxDegreeOfParallelism = 1 },
+                new TestLogger(),
+                new Encryption());
+
+            var unusablePage = await pool.AcquireAsync();
+
+            pool.Release(unusablePage);
+
+            browser.Context.Verify(
+                context => context.CloseAsync(It.IsAny<BrowserContextCloseOptions>()),
+                Times.Once);
+        }
+
+        [Test]
         public async Task DisposeAsync_DoesNotCloseDisconnectedBrowser()
         {
             var disconnected = CreateBrowser(connected: false);

--- a/tests/InvenAdClicker.Tests/Utils/RollingFileLoggerProviderTests.cs
+++ b/tests/InvenAdClicker.Tests/Utils/RollingFileLoggerProviderTests.cs
@@ -1,0 +1,126 @@
+using InvenAdClicker.Utils;
+using Microsoft.Extensions.Logging;
+using NUnit.Framework;
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace InvenAdClicker.Tests.Utils
+{
+    [TestFixture]
+    public class RollingFileLoggerProviderTests
+    {
+        [Test]
+        public void Dispose_WritesOneTimestampedRunLogAndMatchingFatalLog()
+        {
+            string originalDirectory = Directory.GetCurrentDirectory();
+            string tempDirectory = Path.Combine(Path.GetTempPath(), $"inven-log-test-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(tempDirectory);
+            Directory.SetCurrentDirectory(tempDirectory);
+
+            try
+            {
+                using (var provider = new RollingFileLoggerProvider())
+                {
+                    var logger = provider.CreateLogger("test");
+                    logger.LogInformation("regular message");
+                    logger.LogCritical(new InvalidOperationException("boom"), "fatal message");
+                }
+
+                var normalLogs = Directory
+                    .GetFiles(Path.Combine(tempDirectory, "logs"), "*.log", SearchOption.AllDirectories)
+                    .Where(path => !path.Contains($"{Path.DirectorySeparatorChar}fatal{Path.DirectorySeparatorChar}"))
+                    .ToArray();
+                var fatalLogs = Directory.GetFiles(
+                    Path.Combine(tempDirectory, "logs", "fatal"),
+                    "*.log",
+                    SearchOption.AllDirectories);
+
+                Assert.That(normalLogs, Has.Length.EqualTo(1));
+                Assert.That(fatalLogs, Has.Length.EqualTo(1));
+                Assert.That(Path.GetFileName(normalLogs[0]), Does.Match(@"^\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2}-\d{3}\.log$"));
+                Assert.That(Path.GetFileName(fatalLogs[0]), Is.EqualTo(Path.GetFileName(normalLogs[0])));
+
+                string normalContent = File.ReadAllText(normalLogs[0]);
+                string fatalContent = File.ReadAllText(fatalLogs[0]);
+                Assert.That(normalContent, Does.Contain("regular message"));
+                Assert.That(normalContent, Does.Contain("fatal message"));
+                Assert.That(fatalContent, Does.Contain("fatal message"));
+            }
+            finally
+            {
+                Directory.SetCurrentDirectory(originalDirectory);
+                try { Directory.Delete(tempDirectory, recursive: true); } catch { }
+            }
+        }
+
+        [Test]
+        public async Task Log_DoesNotBlockWhenQueueIsFull()
+        {
+            int appends = 0;
+            var releaseAppender = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            using var provider = new RollingFileLoggerProvider(
+                capacity: 1,
+                fileAppender: (_, _, _, _) =>
+                {
+                    Interlocked.Increment(ref appends);
+                    return releaseAppender.Task;
+                },
+                disposeTimeout: TimeSpan.FromMilliseconds(100));
+
+            var logger = provider.CreateLogger("test");
+            logger.LogInformation("first");
+            Assert.That(
+                SpinWait.SpinUntil(() => Volatile.Read(ref appends) > 0, TimeSpan.FromSeconds(1)),
+                Is.True);
+
+            logger.LogInformation("second");
+            var blockedCandidate = Task.Run(() => logger.LogInformation("third"));
+
+            try
+            {
+                Task completed = await Task.WhenAny(blockedCandidate, Task.Delay(TimeSpan.FromMilliseconds(500)));
+                Assert.That(completed, Is.SameAs(blockedCandidate),
+                    "Logging must not block application threads when the bounded queue is saturated.");
+            }
+            finally
+            {
+                releaseAppender.TrySetResult();
+            }
+        }
+
+        [Test]
+        public async Task Dispose_ReturnsPromptlyWhenAppenderDoesNotComplete()
+        {
+            var appenderStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var releaseAppender = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var provider = new RollingFileLoggerProvider(
+                capacity: 10,
+                fileAppender: (_, _, _, _) =>
+                {
+                    appenderStarted.TrySetResult();
+                    return releaseAppender.Task;
+                },
+                disposeTimeout: TimeSpan.FromMilliseconds(50));
+
+            provider.CreateLogger("test").LogInformation("message");
+            await appenderStarted.Task.WaitAsync(TimeSpan.FromSeconds(1));
+
+            var disposeTask = Task.Run(provider.Dispose);
+
+            try
+            {
+                Task completed = await Task.WhenAny(disposeTask, Task.Delay(TimeSpan.FromMilliseconds(500)));
+                Assert.That(completed, Is.SameAs(disposeTask),
+                    "Logger disposal must not block process shutdown indefinitely when file I/O is wedged.");
+            }
+            finally
+            {
+                releaseAppender.TrySetResult();
+                await Task.WhenAny(disposeTask, Task.Delay(TimeSpan.FromMilliseconds(500)));
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Recover and harden the Playwright browser pool when pages, contexts, or browsers become unusable.
- Improve pipeline shutdown so worker faults do not leave peer workers waiting indefinitely.
- Switch file logging to per-process-start timestamped run logs, with matching fatal logs for critical failures.
- Add regression tests for cancellation, pool cleanup, pipeline fault handling, and logger flush/shutdown behavior.

## Validation
- dotnet test tests\InvenAdClicker.Tests\InvenAdClicker.Tests.csproj -c Release --no-restore -v minimal
- dotnet build -c Release --no-restore
